### PR TITLE
File name in browser without database

### DIFF
--- a/Language.cpp
+++ b/Language.cpp
@@ -119,7 +119,7 @@ LANG_STR DefaultString[] = {
 //Rom Browser Fields
 	{ RB_FILENAME,     "File Name" },
 	{ RB_INTERNALNAME, "Internal Name" },
-	{ RB_GOODNAME,     "Good Name" },
+	{ RB_NAME,			"Name" },
 	{ RB_STATUS,       "Status" },
 	{ RB_ROMSIZE,      "Rom Size" },
 	{ RB_NOTES_CORE,   "Notes (Core)" },
@@ -141,7 +141,7 @@ LANG_STR DefaultString[] = {
 	{ SELECT_ROM_DIR,  "Select current Rom Directory" },
 
 //Messages
-	{ RB_NOT_GOOD_FILE,"Bad ROM? Use GoodN64 & check for updated INI" },
+	{ RB_NOT_GOOD_FILE,"Game not in database? Please add yourself or check for updated RDB" },
 
 /*********************************************************************************
 * Options                                                                        *

--- a/Language.h
+++ b/Language.h
@@ -169,6 +169,10 @@ char * GS               ( int StringID );
 #define RB_FILENAME				300
 #define RB_INTERNALNAME			301
 #define RB_GOODNAME				302
+
+// This is to use the ROm File name in Browser raher than Nad Rom Message.
+
+#define RB_NAME					319
 #define RB_STATUS				303
 #define RB_ROMSIZE				304
 #define RB_NOTES_CORE			305

--- a/RomBrowser.c
+++ b/RomBrowser.c
@@ -100,7 +100,10 @@ typedef struct {
 
 #define RB_FileName			0
 #define RB_InternalName		1
-#define RB_GoodName			2
+
+// This replaces Good_Name to disaply file name in browser that are noit in database
+
+#define RB_Name				2
 #define RB_Status			3
 #define RB_RomSize			4
 #define RB_CoreNotes		5
@@ -145,7 +148,12 @@ ROMBROWSER_FIELDS RomBrowserFields[] =
 {
 	"File Name",              -1, RB_FileName,      218,RB_FILENAME,
 	"Internal Name",          -1, RB_InternalName,  200,RB_INTERNALNAME,
-	"Good Name",               0, RB_GoodName,      218,RB_GOODNAME,
+
+	// This Displays the file name instead of a Bad ROM? or Not in database message.
+	// We also need a way on rom settings "OK" to use the file name and not Internal Name
+	// and also auto update the browser to show the change. (Gent)
+
+	"Name",					   0, RB_FileName,      218,RB_NAME, 
 	"Status",                  1, RB_Status,        92,RB_STATUS,
 	"Rom Size",               -1, RB_RomSize,       100,RB_ROMSIZE,
 	"Notes (Core)",            2, RB_CoreNotes,     120,RB_NOTES_CORE,
@@ -411,8 +419,8 @@ void FillRomExtensionInfo(ROM_INFO * pRomInfo) {
 		GetString(Identifier, "ForceFeedback", "unknown", pRomInfo->ForceFeedback, sizeof(pRomInfo->ForceFeedback), ExtIniFileName);
 
 	//Rom Settings
-	if (RomBrowserFields[RB_GoodName].Pos >= 0)
-		GetString(Identifier, "Good Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GoodName, sizeof(pRomInfo->GoodName), IniFileName);
+	if (RomBrowserFields[RB_Name].Pos >= 0)
+		GetString(Identifier, "Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GoodName, sizeof(pRomInfo->GoodName), IniFileName);
 	
 	GetString(Identifier, "Status", Default_RomStatus, pRomInfo->Status, sizeof(pRomInfo->Status), IniFileName);
 
@@ -611,7 +619,7 @@ int CALLBACK RomList_CompareItems2(LPARAM lParam1, LPARAM lParam2, LPARAM lParam
 		switch (SortFields->Key[count]) {
 		case RB_FileName: result = (int)lstrcmpi(pRomInfo1->FileName, pRomInfo2->FileName); break;
 		case RB_InternalName: result =  (int)lstrcmpi(pRomInfo1->InternalName, pRomInfo2->InternalName); break;
-		case RB_GoodName: result =  (int)lstrcmpi(pRomInfo1->GoodName, pRomInfo2->GoodName); break;
+		case RB_Name: result =  (int)lstrcmpi(pRomInfo1->GoodName, pRomInfo2->GoodName); break;
 		case RB_Status: result =  (int)lstrcmpi(pRomInfo1->Status, pRomInfo2->Status); break;
 		case RB_RomSize: result =  (int)pRomInfo1->RomSize - (int)pRomInfo2->RomSize; break;
 		case RB_CoreNotes: result =  (int)lstrcmpi(pRomInfo1->CoreNotes, pRomInfo2->CoreNotes); break;
@@ -651,7 +659,7 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 	switch(FieldType[lpdi->item.iSubItem]) {
 	case RB_FileName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
 	case RB_InternalName: strncpy(lpdi->item.pszText, pRomInfo->InternalName, lpdi->item.cchTextMax); break;
-	case RB_GoodName: strncpy(lpdi->item.pszText, pRomInfo->GoodName, lpdi->item.cchTextMax); break;
+	case RB_Name: strncpy(lpdi->item.pszText, pRomInfo->GoodName, lpdi->item.cchTextMax); break;
 	case RB_CoreNotes: strncpy(lpdi->item.pszText, pRomInfo->CoreNotes, lpdi->item.cchTextMax); break;
 	case RB_PluginNotes: strncpy(lpdi->item.pszText, pRomInfo->PluginNotes, lpdi->item.cchTextMax); break;
 	case RB_Status: strncpy(lpdi->item.pszText, pRomInfo->Status, lpdi->item.cchTextMax); break;


### PR DESCRIPTION
![File_Name](https://github.com/pj64team/Project64-1.6-Plus/assets/82123790/4dbe8138-8a8b-4657-a79d-eea6ede29301)

This displays File name in ROM Browser even if there isn't an entry in the RDB. Before it would display a crude not Bad ROM? message.- In the RDB it still inserts the Internal Name but Internal & Good _Name have been removed and instead just uses Name=Inter Name (Would also like that to be File Name)

So what i was going for was: display file name if not in entry & then update with what it reads from RDB


https://github.com/pj64team/Project64-1.6-Plus/assets/82123790/3d0fd242-703d-41b1-90b9-2204d6a4eebf

https://github.com/pj64team/Project64-1.6-Plus/assets/82123790/1ac51601-d06a-4e52-80b2-44365dbb3468

(This code does not allow for that)

Yes Gented, but was trying to show the effect required.

Now this needs careful checking cause i May have Gented this right up just to get the desired effect i was looking for!