### PR TITLE
Changed Good Name to Game Name

### DIFF
--- a/Language.cpp
+++ b/Language.cpp
@@ -121,7 +121,7 @@ LANG_STR DefaultString[] = {
 //Rom Browser Fields
 	{ RB_FILENAME,     "File Name" },
 	{ RB_INTERNALNAME, "Internal Name" },
-	{ RB_GOODNAME,     "Good Name" },
+	{ RB_GAMENAME,     "Game Name" },
 	{ RB_STATUS,       "Status" },
 	{ RB_ROMSIZE,      "Rom Size" },
 	{ RB_NOTES_CORE,   "Notes (Core)" },
@@ -144,7 +144,7 @@ LANG_STR DefaultString[] = {
 	{ SELECT_ROM_DIR,  "Select current Rom Directory" },
 
 //Messages
-	{ RB_NOT_GOOD_FILE,"Bad ROM? Use GoodN64 & check for updated INI" },
+	{ RB_NOT_GOOD_FILE,"Not in database? Add yourself or check for RDB updated" },
 
 /*********************************************************************************
 * Options                                                                        *

--- a/Language.cpp
+++ b/Language.cpp
@@ -144,7 +144,12 @@ LANG_STR DefaultString[] = {
 	{ SELECT_ROM_DIR,  "Select current Rom Directory" },
 
 //Messages
-	{ RB_NOT_GOOD_FILE,"Not in database? Add yourself or check for RDB updated" },
+
+// This has been changed from RB_NOT_GOOD_FILE with the message:
+// "Bad ROM? Use GoodN64 & check for updated INI"
+// because the Good Rom system is now defunct (Gent)
+
+	{ RB_NOT_IN_RDB,"Not in database? Add yourself or check for RDB updated" },
 
 /*********************************************************************************
 * Options                                                                        *

--- a/Language.h
+++ b/Language.h
@@ -170,7 +170,7 @@ char * GS               ( int StringID );
 //Rom Browser Fields
 #define RB_FILENAME				300
 #define RB_INTERNALNAME			301
-#define RB_GOODNAME				302
+#define RB_GAMENAME				302
 #define RB_STATUS				303
 #define RB_ROMSIZE				304
 #define RB_NOTES_CORE			305

--- a/Language.h
+++ b/Language.h
@@ -193,7 +193,7 @@ char * GS               ( int StringID );
 #define SELECT_ROM_DIR			320
 
 //Messages
-#define RB_NOT_GOOD_FILE		340
+#define RB_NOT_IN_RDB			340
 
 /*********************************************************************************
 * Options                                                                        *

--- a/Main.h
+++ b/Main.h
@@ -46,11 +46,11 @@ extern "C" {
 #define AppName  "Project64 (Build 57)"
 #else
 //#define BETA_VERSION
-#define AppVer   "Project64 - Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppVer   "Project64 - Version 1.6 Plus"
 #ifdef BETA_VERSION
-#define AppName  "Project64 Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppName  "Project64 Version 1.6 Plus"
 #else
-#define AppName  "Project64 Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppName  "Project64 Version 1.6 Plus"
 #endif
 #endif
 

--- a/RomBrowser.c
+++ b/RomBrowser.c
@@ -43,7 +43,7 @@ typedef struct {
 	char     Status[60];
 	char     FileName[200];
 	char     InternalName[22];
-	char     GoodName[200];
+	char     GameName[200];
 	char     CartID[3];
 	char     PluginNotes[250];
 	char     CoreNotes[250];
@@ -102,7 +102,7 @@ typedef struct {
 
 #define RB_FileName			0
 #define RB_InternalName		1
-#define RB_GoodName			2
+#define RB_GameName			2
 #define RB_Status			3
 #define RB_RomSize			4
 #define RB_CoreNotes		5
@@ -148,7 +148,7 @@ ROMBROWSER_FIELDS RomBrowserFields[] =
 {
 	"File Name",              -1, RB_FileName,      218,RB_FILENAME,
 	"Internal Name",          -1, RB_InternalName,  200,RB_INTERNALNAME,
-	"Good Name",               0, RB_GoodName,      218,RB_GOODNAME,
+	"Game Name",               0, RB_GameName,      218,RB_GAMENAME,
 	"Status",                  1, RB_Status,        92,RB_STATUS,
 	"Rom Size",               -1, RB_RomSize,       100,RB_ROMSIZE,
 	"Notes (Core)",            2, RB_CoreNotes,     120,RB_NOTES_CORE,
@@ -418,8 +418,8 @@ void FillRomExtensionInfo(ROM_INFO * pRomInfo) {
 		GetString(Identifier, "ForceFeedback", "unknown", pRomInfo->ForceFeedback, sizeof(pRomInfo->ForceFeedback), ExtIniFileName);
 
 	//Rom Settings
-	if (RomBrowserFields[RB_GoodName].Pos >= 0)
-		GetString(Identifier, "Good Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GoodName, sizeof(pRomInfo->GoodName), IniFileName);
+	if (RomBrowserFields[RB_GameName].Pos >= 0)
+		GetString(Identifier, "Game Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName);
 	
 	GetString(Identifier, "Status", Default_RomStatus, pRomInfo->Status, sizeof(pRomInfo->Status), IniFileName);
 
@@ -618,7 +618,7 @@ int CALLBACK RomList_CompareItems2(LPARAM lParam1, LPARAM lParam2, LPARAM lParam
 		switch (SortFields->Key[count]) {
 		case RB_FileName: result = (int)lstrcmpi(pRomInfo1->FileName, pRomInfo2->FileName); break;
 		case RB_InternalName: result =  (int)lstrcmpi(pRomInfo1->InternalName, pRomInfo2->InternalName); break;
-		case RB_GoodName: result =  (int)lstrcmpi(pRomInfo1->GoodName, pRomInfo2->GoodName); break;
+		case RB_GameName: result =  (int)lstrcmpi(pRomInfo1->GameName, pRomInfo2->GameName); break;
 		case RB_Status: result =  (int)lstrcmpi(pRomInfo1->Status, pRomInfo2->Status); break;
 		case RB_RomSize: result =  (int)pRomInfo1->RomSize - (int)pRomInfo2->RomSize; break;
 		case RB_CoreNotes: result =  (int)lstrcmpi(pRomInfo1->CoreNotes, pRomInfo2->CoreNotes); break;
@@ -659,7 +659,7 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 	switch(FieldType[lpdi->item.iSubItem]) {
 	case RB_FileName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
 	case RB_InternalName: strncpy(lpdi->item.pszText, pRomInfo->InternalName, lpdi->item.cchTextMax); break;
-	case RB_GoodName: strncpy(lpdi->item.pszText, pRomInfo->GoodName, lpdi->item.cchTextMax); break;
+	case RB_GameName: strncpy(lpdi->item.pszText, pRomInfo->GameName, lpdi->item.cchTextMax); break;
 	case RB_CoreNotes: strncpy(lpdi->item.pszText, pRomInfo->CoreNotes, lpdi->item.cchTextMax); break;
 	case RB_PluginNotes: strncpy(lpdi->item.pszText, pRomInfo->PluginNotes, lpdi->item.cchTextMax); break;
 	case RB_Status: strncpy(lpdi->item.pszText, pRomInfo->Status, lpdi->item.cchTextMax); break;

--- a/RomBrowser.c
+++ b/RomBrowser.c
@@ -418,8 +418,17 @@ void FillRomExtensionInfo(ROM_INFO * pRomInfo) {
 		GetString(Identifier, "ForceFeedback", "unknown", pRomInfo->ForceFeedback, sizeof(pRomInfo->ForceFeedback), ExtIniFileName);
 
 	//Rom Settings
+
 	if (RomBrowserFields[RB_GameName].Pos >= 0)
 		GetString(Identifier, "Game Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName);
+	if (RomBrowserFields[RB_GoodName].Pos >= 0)
+
+		// This displays the message "Not in database? Add yourself or check for RDB updated"
+		// in the ROM Browser if a ROM is not in the RDB (Game Database)
+		// What i would like to achieve is to display the file name until the gamne is added
+		// and then updated from that entry (Gent)
+
+	GetString(Identifier, "Game Name", GS(RB_NOT_IN_RDB), pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName);
 	
 	GetString(Identifier, "Status", Default_RomStatus, pRomInfo->Status, sizeof(pRomInfo->Status), IniFileName);
 
@@ -659,6 +668,11 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 	switch(FieldType[lpdi->item.iSubItem]) {
 	case RB_FileName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
 	case RB_InternalName: strncpy(lpdi->item.pszText, pRomInfo->InternalName, lpdi->item.cchTextMax); break;
+	
+		// TpRomInfo->GameName displays Game Name=Text there in the RDB,
+		// TpRomInfo->FileName displays File Name but then will not update what is written
+		// in Game Name=Text there in the RDB. 
+	
 	case RB_GameName: strncpy(lpdi->item.pszText, pRomInfo->GameName, lpdi->item.cchTextMax); break;
 	case RB_CoreNotes: strncpy(lpdi->item.pszText, pRomInfo->CoreNotes, lpdi->item.cchTextMax); break;
 	case RB_PluginNotes: strncpy(lpdi->item.pszText, pRomInfo->PluginNotes, lpdi->item.cchTextMax); break;


### PR DESCRIPTION
Good Name is an out of date ideal so have replaced with the ROM Browser Field "Good Name" with Game Name & every other reference to it. This includes the RDB "Good Name" is now "Game Name".

This needs reviewing, but I am confidant of how it is a strong case for change.

