### PR TITLE
File name in title bar when emulated 

### DIFF
--- a/Language.cpp
+++ b/Language.cpp
@@ -121,7 +121,7 @@ LANG_STR DefaultString[] = {
 //Rom Browser Fields
 	{ RB_FILENAME,     "File Name" },
 	{ RB_INTERNALNAME, "Internal Name" },
-	{ RB_GOODNAME,     "Good Name" },
+	{ RB_GAMENAME,     "Game Name" },
 	{ RB_STATUS,       "Status" },
 	{ RB_ROMSIZE,      "Rom Size" },
 	{ RB_NOTES_CORE,   "Notes (Core)" },
@@ -144,7 +144,7 @@ LANG_STR DefaultString[] = {
 	{ SELECT_ROM_DIR,  "Select current Rom Directory" },
 
 //Messages
-	{ RB_NOT_GOOD_FILE,"Bad ROM? Use GoodN64 & check for updated INI" },
+	{ RB_NOT_GOOD_FILE,"Not in database? Add yourself or check for RDB updated" },
 
 /*********************************************************************************
 * Options                                                                        *

--- a/Language.h
+++ b/Language.h
@@ -170,7 +170,7 @@ char * GS               ( int StringID );
 //Rom Browser Fields
 #define RB_FILENAME				300
 #define RB_INTERNALNAME			301
-#define RB_GOODNAME				302
+#define RB_GAMENAME				302
 #define RB_STATUS				303
 #define RB_ROMSIZE				304
 #define RB_NOTES_CORE			305

--- a/Main.h
+++ b/Main.h
@@ -46,11 +46,11 @@ extern "C" {
 #define AppName  "Project64 (Build 57)"
 #else
 //#define BETA_VERSION
-#define AppVer   "Project64 - Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppVer   "Project64 - Version 1.6 Plus"
 #ifdef BETA_VERSION
-#define AppName  "Project64 Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppName  "Project64 Version 1.6 Plus 1.6 Plus"
 #else
-#define AppName  "Project64 Version 1.6 Plus (Vunerbility Fix RC1)"
+#define AppName  "Project64 Version 1.6 Plus 1.6 Plus"
 #endif
 #endif
 

--- a/Rom.c
+++ b/Rom.c
@@ -533,8 +533,11 @@ BOOL LoadRomHeader ( void ) {
 		CloseHandle( hFile );
 	}
 	ByteSwapRom(RomHeader,sizeof(RomHeader));
-	memcpy(&RomName[0],&RomHeader[0x20],20);
-	for( count = 0 ; count < 20; count += 4 ) {
+
+	// This replaces the Internal Name with File Name (Gent)
+
+	memcpy(&RomName, &FileName, 60);
+	/*for( count = 0 ; count < 20; count += 4 ) {
 		RomName[count] ^= RomName[count+3];
 		RomName[count + 3] ^= RomName[count];
 		RomName[count] ^= RomName[count+3];
@@ -550,7 +553,8 @@ BOOL LoadRomHeader ( void ) {
 			count = -1;
 		}
 	}
-	RomName[20] = '\0';
+	}*/
+	RomName[60] = '\0';
 	if (strlen(RomName) == 0) { strcpy(RomName,FileName); }
 	return FALSE;
 }
@@ -1034,7 +1038,7 @@ void OpenChosenFile ( void ) {
 	}
 	RomName[20] = '\0';
 	if (strlen(RomName) == 0) { strcpy(RomName,FileName); }
-	sprintf( WinTitle, "%s - %s", RomName, AppName);
+	sprintf(WinTitle, "%s - %s", RomName, AppName);
 
 	for( count = 0 ; count < (int)strlen(RomName); count ++ ) {
 		switch (RomName[count]) {
@@ -1123,7 +1127,10 @@ void SaveRomOptions (void) {
 
 	IniFileName = GetIniFileName();
 	sprintf(Identifier,"%08X-%08X-C:%X",*(DWORD *)(&RomHeader[0x10]),*(DWORD *)(&RomHeader[0x14]),RomHeader[0x3D]);
-	_WritePrivateProfileString(Identifier,"Internal Name",RomName,IniFileName);
+	
+	// This changes "Internal Name" to "Game Name" in the RDB where File Name is placed (Gent)
+
+	_WritePrivateProfileString(Identifier, "Game Name", RomName, IniFileName);
 
 	switch (RomRamSize) {
 	case 0x400000: strcpy(String,"4"); break;

--- a/Rom.c
+++ b/Rom.c
@@ -1038,7 +1038,10 @@ void OpenChosenFile ( void ) {
 	}
 	RomName[20] = '\0';
 	if (strlen(RomName) == 0) { strcpy(RomName,FileName); }
-	sprintf(WinTitle, "%s - %s", RomName, AppName);
+
+	// This replaces the use of ROM Internal Name with File name in the title bar (Gent)
+
+	sprintf(WinTitle, "%s - %s", FileName, AppName);
 
 	for( count = 0 ; count < (int)strlen(RomName); count ++ ) {
 		switch (RomName[count]) {

--- a/RomBrowser.c
+++ b/RomBrowser.c
@@ -43,7 +43,7 @@ typedef struct {
 	char     Status[60];
 	char     FileName[200];
 	char     InternalName[22];
-	char     GoodName[200];
+	char     GameName[200];
 	char     CartID[3];
 	char     PluginNotes[250];
 	char     CoreNotes[250];
@@ -102,7 +102,7 @@ typedef struct {
 
 #define RB_FileName			0
 #define RB_InternalName		1
-#define RB_GoodName			2
+#define RB_GameName			2
 #define RB_Status			3
 #define RB_RomSize			4
 #define RB_CoreNotes		5
@@ -148,7 +148,7 @@ ROMBROWSER_FIELDS RomBrowserFields[] =
 {
 	"File Name",              -1, RB_FileName,      218,RB_FILENAME,
 	"Internal Name",          -1, RB_InternalName,  200,RB_INTERNALNAME,
-	"Good Name",               0, RB_GoodName,      218,RB_GOODNAME,
+	"Game Name",               0, RB_GameName,      218,RB_GAMENAME,
 	"Status",                  1, RB_Status,        92,RB_STATUS,
 	"Rom Size",               -1, RB_RomSize,       100,RB_ROMSIZE,
 	"Notes (Core)",            2, RB_CoreNotes,     120,RB_NOTES_CORE,
@@ -418,8 +418,8 @@ void FillRomExtensionInfo(ROM_INFO * pRomInfo) {
 		GetString(Identifier, "ForceFeedback", "unknown", pRomInfo->ForceFeedback, sizeof(pRomInfo->ForceFeedback), ExtIniFileName);
 
 	//Rom Settings
-	if (RomBrowserFields[RB_GoodName].Pos >= 0)
-		GetString(Identifier, "Good Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GoodName, sizeof(pRomInfo->GoodName), IniFileName);
+	if (RomBrowserFields[RB_GameName].Pos >= 0)
+		GetString(Identifier, "Game Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName);
 	
 	GetString(Identifier, "Status", Default_RomStatus, pRomInfo->Status, sizeof(pRomInfo->Status), IniFileName);
 
@@ -618,7 +618,7 @@ int CALLBACK RomList_CompareItems2(LPARAM lParam1, LPARAM lParam2, LPARAM lParam
 		switch (SortFields->Key[count]) {
 		case RB_FileName: result = (int)lstrcmpi(pRomInfo1->FileName, pRomInfo2->FileName); break;
 		case RB_InternalName: result =  (int)lstrcmpi(pRomInfo1->InternalName, pRomInfo2->InternalName); break;
-		case RB_GoodName: result =  (int)lstrcmpi(pRomInfo1->GoodName, pRomInfo2->GoodName); break;
+		case RB_GameName: result =  (int)lstrcmpi(pRomInfo1->GameName, pRomInfo2->GameName); break;
 		case RB_Status: result =  (int)lstrcmpi(pRomInfo1->Status, pRomInfo2->Status); break;
 		case RB_RomSize: result =  (int)pRomInfo1->RomSize - (int)pRomInfo2->RomSize; break;
 		case RB_CoreNotes: result =  (int)lstrcmpi(pRomInfo1->CoreNotes, pRomInfo2->CoreNotes); break;
@@ -659,7 +659,7 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 	switch(FieldType[lpdi->item.iSubItem]) {
 	case RB_FileName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
 	case RB_InternalName: strncpy(lpdi->item.pszText, pRomInfo->InternalName, lpdi->item.cchTextMax); break;
-	case RB_GoodName: strncpy(lpdi->item.pszText, pRomInfo->GoodName, lpdi->item.cchTextMax); break;
+	case RB_GameName: strncpy(lpdi->item.pszText, pRomInfo->GameName, lpdi->item.cchTextMax); break;
 	case RB_CoreNotes: strncpy(lpdi->item.pszText, pRomInfo->CoreNotes, lpdi->item.cchTextMax); break;
 	case RB_PluginNotes: strncpy(lpdi->item.pszText, pRomInfo->PluginNotes, lpdi->item.cchTextMax); break;
 	case RB_Status: strncpy(lpdi->item.pszText, pRomInfo->Status, lpdi->item.cchTextMax); break;

--- a/RomBrowser.c
+++ b/RomBrowser.c
@@ -419,7 +419,10 @@ void FillRomExtensionInfo(ROM_INFO * pRomInfo) {
 
 	//Rom Settings
 	if (RomBrowserFields[RB_GameName].Pos >= 0)
-		GetString(Identifier, "Game Name", GS(RB_NOT_GOOD_FILE), pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName);
+
+		// This bypasses the Not in database message and displays Game Name in browser
+
+		Identifier, "Game Name", /*GS(RB_NOT_GOOD_FILE),*/ pRomInfo->GameName, sizeof(pRomInfo->GameName), IniFileName;
 	
 	GetString(Identifier, "Status", Default_RomStatus, pRomInfo->Status, sizeof(pRomInfo->Status), IniFileName);
 
@@ -659,7 +662,11 @@ void RomList_GetDispInfo(LPNMHDR pnmh) {
 	switch(FieldType[lpdi->item.iSubItem]) {
 	case RB_FileName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
 	case RB_InternalName: strncpy(lpdi->item.pszText, pRomInfo->InternalName, lpdi->item.cchTextMax); break;
-	case RB_GameName: strncpy(lpdi->item.pszText, pRomInfo->GameName, lpdi->item.cchTextMax); break;
+	
+		// This Sets Name to display File Name, but does not update when file name is changed,
+
+	case RB_GameName: strncpy(lpdi->item.pszText, pRomInfo->FileName, lpdi->item.cchTextMax); break;
+
 	case RB_CoreNotes: strncpy(lpdi->item.pszText, pRomInfo->CoreNotes, lpdi->item.cchTextMax); break;
 	case RB_PluginNotes: strncpy(lpdi->item.pszText, pRomInfo->PluginNotes, lpdi->item.cchTextMax); break;
 	case RB_Status: strncpy(lpdi->item.pszText, pRomInfo->Status, lpdi->item.cchTextMax); break;

--- a/Settings.c
+++ b/Settings.c
@@ -1043,7 +1043,7 @@ BOOL CALLBACK RomSettingsProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			
 			if (strlen(RomName) == 0) { break; }
 			sprintf(Identifier,"%08X-%08X-C:%X",*(DWORD *)(&RomHeader[0x10]),*(DWORD *)(&RomHeader[0x14]),RomHeader[0x3D]);
-			_WritePrivateProfileString(Identifier,"Internal Name",RomName,NotesIniFileName);
+			_WritePrivateProfileString(Identifier,"Game Name",RomName,NotesIniFileName);
 			GetDlgItemText(hDlg,IDC_NOTES,String,sizeof(String));
 			_WritePrivateProfileString(Identifier,"Note",String,NotesIniFileName);
 


### PR DESCRIPTION
This replaces the use of ROM Internal Name with File name in the title bar. Be better if it used file name until Game Name was in the RDB and then uses that?