### PR TITLE
Jabo PermCheats & About ini dialog

### DIFF
--- a/Cheat.c
+++ b/Cheat.c
@@ -1921,6 +1921,27 @@ void LoadPermCheats (void)
 	if (String) { free(String); }
 }
 
+void LoadJaboCheats(void)  // Jabo Video PermCheat Specific (Gent)
+{
+	LPSTR IniFileName;
+	char* String = NULL;
+	char Identifier[100];
+	int count;
+
+	IniFileName = GetJIniFileName();
+	sprintf(Identifier, "%08X-%08X-C:%X", *(DWORD*)(&RomHeader[0x10]), *(DWORD*)(&RomHeader[0x14]), RomHeader[0x3D]);
+
+	for (count = 0; count < MaxCheats; count++)
+	{
+		char CheatName[300];
+
+		sprintf(CheatName, "Cheat%d", count);
+		_GetPrivateProfileString2(Identifier, CheatName, "", &String, IniFileName);
+		if (strlen(String) == 0) { break; }
+		LoadCode(NULL, String);
+	}
+	if (String) { free(String); }
+}
 
 /********************************************************************************************
   LoadCheats
@@ -1960,6 +1981,28 @@ void LoadCheats (void) {
 		//}		
 		if (!CheatActive (CheatName)) { continue; }
 		ReadPos = strrchr(String,'"') + 2;
+		LoadCode(CheatName, ReadPos);
+	}
+
+	LoadJaboCheats();
+
+	for (count = 0; count < MaxCheats; count++) {
+		char* ReadPos;
+
+		sprintf(CheatName, "Cheat%d", count);
+		_GetPrivateProfileString2(Identifier, CheatName, "", &String, IniFileName);
+		if (strlen(String) == 0) { break; }
+		if (strchr(String, '"') == NULL) { continue; }
+		len = strrchr(String, '"') - strchr(String, '"') - 1;
+		if ((int)len < 1) { continue; }
+		memset(CheatName, 0, sizeof(CheatName));
+		strncpy(CheatName, strchr(String, '"') + 1, len);
+		if (strlen(CheatName) == 0) { continue; }
+		//if (strrchr(CheatName,'\\') != NULL) {
+		//	strcpy(CheatName,strrchr(CheatName,'\\') + 1);
+		//}		
+		if (!CheatActive(CheatName)) { continue; }
+		ReadPos = strrchr(String, '"') + 2;
 		LoadCode(CheatName, ReadPos);
 	}
 	if (String) { free(String); }

--- a/Language.cpp
+++ b/Language.cpp
@@ -28,6 +28,7 @@ LANG_STR DefaultString[] = {
 	{ INI_CURRENT_RDB,     "ROM Database (.RDB)"     },
 	{ INI_CURRENT_CHT,     "Cheat Code file (.CHT)"  },
 	{ INI_CURRENT_RDX,     "Extended Rom Info (.RDX)"},
+	{ INI_CURRENT_JINI,    "Jabo Ini Info (.INI)" },
 	{ INI_TITLE,           "About INI Files"         },
 
 /*********************************************************************************

--- a/Language.h
+++ b/Language.h
@@ -26,6 +26,7 @@ char * GS               ( int StringID );
 #define INI_CURRENT_RDB         10
 #define INI_CURRENT_CHT         11
 #define INI_CURRENT_RDX         12
+#define INI_CURRENT_JINI        13
 
 //About INI title
 #define INI_TITLE               20

--- a/Main.c
+++ b/Main.c
@@ -76,7 +76,7 @@ void AboutIniBox (void) {
 }
 
 LRESULT CALLBACK AboutIniBoxProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-	static char RDBHomePage[300], CHTHomePage[300], RDXHomePage[300];
+	static char RDBHomePage[300], CHTHomePage[300], RDXHomePage[300], JINIHomePage[300];
 
 	switch (uMsg) {
 	case WM_INITDIALOG:
@@ -174,6 +174,31 @@ LRESULT CALLBACK AboutIniBoxProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
 			if (strlen(RDXHomePage) == 0) {
 				EnableWindow(GetDlgItem(hDlg,IDC_RDX_HOME),FALSE);
 			}
+
+			//Jabo Ini Info
+			SetDlgItemText(hDlg, IDC_JINI, GS(INI_CURRENT_JINI));
+			IniFile = GetJIniFileName();
+			_GetPrivateProfileString("Meta", "Author", "", String, sizeof(String), IniFile);
+			if (strlen(String) == 0) {
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI), FALSE);
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI_AUTHOR), FALSE);
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI_VERSION), FALSE);
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI_DATE), FALSE);
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI_HOME), FALSE);
+			}
+			sprintf(String2, "%s: %s", GS(INI_AUTHOR), String);
+			SetDlgItemText(hDlg, IDC_JINI_AUTHOR, String2);
+			_GetPrivateProfileString("Meta", "Version", "", String, sizeof(String), IniFile);
+			sprintf(String2, "%s: %s", GS(INI_VERSION), String);
+			SetDlgItemText(hDlg, IDC_JINI_VERSION, String2);
+			_GetPrivateProfileString("Meta", "Date", "", String, sizeof(String), IniFile);
+			sprintf(String2, "%s: %s", GS(INI_DATE), String);
+			SetDlgItemText(hDlg, IDC_JINI_DATE, String2);
+			_GetPrivateProfileString("Meta", "Homepage", "", JINIHomePage, sizeof(CHTHomePage), IniFile);
+			SetDlgItemText(hDlg, IDC_JINI_HOME, GS(INI_HOMEPAGE));
+			if (strlen(JINIHomePage) == 0) {
+				EnableWindow(GetDlgItem(hDlg, IDC_JINI_HOME), FALSE);
+			}
 		}
 		break;
 	case WM_COMMAND: {
@@ -182,6 +207,8 @@ LRESULT CALLBACK AboutIniBoxProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
 			case IDC_RDB_HOME: sprintf(String, "https://%s", RDBHomePage); ShellExecute(NULL,"open",String,NULL,NULL,SW_SHOWNORMAL); break;
 			case IDC_CHT_HOME: sprintf(String, "https://%s", CHTHomePage); ShellExecute(NULL,"open",String,NULL,NULL,SW_SHOWNORMAL); break;
 			case IDC_RDX_HOME: sprintf(String, "https://%s", RDXHomePage); ShellExecute(NULL,"open",String,NULL,NULL,SW_SHOWNORMAL); break;
+			case IDC_JINI_HOME: sprintf(String, "https://%s", JINIHomePage); ShellExecute(NULL, "open", String, NULL, NULL, SW_SHOWNORMAL); break;
+
 			case IDOK:
 			case IDCANCEL:
 				EndDialog(hDlg,0);
@@ -400,6 +427,16 @@ char * GetExtIniFileName(void) {
 	GetModuleFileName(NULL,path_buffer,sizeof(path_buffer));
 	_splitpath( path_buffer, drive, dir, fname, ext );
 	sprintf(IniFileName,"%s%s%s",drive,dir,ExtIniName);
+	return IniFileName;
+}
+char* GetJIniFileName(void) {
+	char path_buffer[_MAX_PATH], drive[_MAX_DRIVE], dir[_MAX_DIR];
+	char fname[_MAX_FNAME], ext[_MAX_EXT];
+	static char IniFileName[_MAX_PATH];
+
+	GetModuleFileName(NULL, path_buffer, sizeof(path_buffer));
+	_splitpath(path_buffer, drive, dir, fname, ext);
+	sprintf(IniFileName, "%s%sConfig\\%s", drive, dir, JIniName);
 	return IniFileName;
 }
 

--- a/Main.h
+++ b/Main.h
@@ -61,6 +61,7 @@ extern "C" {
 #define CheatDevIniName				"Project64.chtdev"
 #define LangFileName				"Project64.lng"
 #define CacheFileName				"Project64.cache"
+#define JIniName					"Jabo.ini"
 #define Default_AdvancedBlockLink	TRUE
 #define Default_AutoStart			TRUE
 #define Default_AutoSleep			TRUE
@@ -153,6 +154,7 @@ void ChangeWinSize        ( HWND hWnd, long width, long height, HWND hStatusBar 
 void  DisplayFPS          ( void );
 char* GetExtIniFileName   ( void );
 char* GetIniFileName      ( void );
+char* GetJIniFileName     (void);
 char* GetLangFileName     ( void );
 char* GetNotesIniFileName ( void );
 int   GetStoredWinPos     ( char * WinName, DWORD * X, DWORD * Y );

--- a/PJ64.rc
+++ b/PJ64.rc
@@ -398,31 +398,36 @@ BEGIN
     PUSHBUTTON      "Down",IDC_DOWN,186,166,36,11
 END
 
-IDD_About_Ini DIALOG 0, 0, 185, 250
+IDD_About_Ini DIALOGEX 0, 0, 363, 185
 STYLE DS_SETFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 CAPTION "About INI Files"
-FONT 8, "MS Sans Serif"
+FONT 8, "MS Sans Serif", 0, 0, 0x0
 BEGIN
-    GROUPBOX        "ROM Database (.RDB)",IDC_RDB,5,46,175,59
-    LTEXT           "Author:",IDC_RDB_AUTHOR,12,57,166,8
-    LTEXT           "Version:",IDC_RDB_VERSION,12,67,166,8
-    LTEXT           "Date:",IDC_RDB_DATE,12,76,166,8
-    PUSHBUTTON      "visit home page",IDC_RDB_HOME,12,87,163,13
-    GROUPBOX        "Cheat Code file (.CHT)",IDC_CHT,6,107,175,59
-    LTEXT           "Author:",IDC_CHT_AUTHOR,13,118,166,8
-    LTEXT           "Version:",IDC_CHT_VERSION,13,128,166,8
-    LTEXT           "Date:",IDC_CHT_DATE,14,137,166,8
-    PUSHBUTTON      "visit home page",IDC_CHT_HOME,13,148,163,13
-    GROUPBOX        " Current Language ",IDC_LAN,5,3,175,42
-    LTEXT           "Author:",IDC_LAN_AUTHOR,13,14,166,8
-    LTEXT           "Version:",IDC_LAN_VERSION,13,24,166,8
-    LTEXT           "Date:",IDC_LAN_DATE,13,34,166,8
-    GROUPBOX        "Extended Rom Info (.RDX)",IDC_RDX,6,168,175,59
-    LTEXT           "Author:",IDC_RDX_AUTHOR,13,178,166,8
-    LTEXT           "Version:",IDC_RDX_VERSION,13,188,166,8
-    PUSHBUTTON      "visit home page",IDC_RDX_HOME,15,210,163,13
-    LTEXT           "Date:",IDC_RDX_DATE,13,198,166,8
-    PUSHBUTTON      "OK",IDOK,134,230,47,13
+GROUPBOX        "ROM Database (.RDB)", IDC_RDB, 5, 44, 175, 59
+LTEXT           "Author:", IDC_RDB_AUTHOR, 14, 55, 166, 8
+LTEXT           "Version:", IDC_RDB_VERSION, 14, 65, 166, 8
+LTEXT           "Date:", IDC_RDB_DATE, 14, 74, 166, 8
+PUSHBUTTON      "visit home page", IDC_RDB_HOME, 12, 85, 163, 13
+GROUPBOX        "Cheat Code file (.CHT)", IDC_CHT, 6, 105, 174, 59
+LTEXT           "Author:", IDC_CHT_AUTHOR, 13, 116, 166, 8
+LTEXT           "Version:", IDC_CHT_VERSION, 13, 126, 166, 8
+LTEXT           "Date:", IDC_CHT_DATE, 14, 135, 166, 8
+PUSHBUTTON      "visit home page", IDC_CHT_HOME, 13, 146, 163, 13
+LTEXT           "Author:", IDC_LAN_AUTHOR, 13, 11, 166, 8
+LTEXT           "Version:", IDC_LAN_VERSION, 13, 21, 166, 8
+LTEXT           "Date:", IDC_LAN_DATE, 13, 31, 166, 8
+PUSHBUTTON      "OK", IDOK, 308, 165, 47, 13
+GROUPBOX        "Extended Rom Info (.RDX)", IDC_RDX, 179, 105, 175, 59
+LTEXT           "Version:", IDC_RDX_VERSION, 186, 125, 166, 8
+PUSHBUTTON      "visit home page", IDC_RDX_HOME, 186, 147, 163, 13
+LTEXT           "Date:", IDC_RDX_DATE, 186, 135, 166, 8
+LTEXT           "Author:", IDC_RDX_AUTHOR, 186, 115, 166, 8
+GROUPBOX        "Jabo Ini Information (.INI)", IDC_JINI, 180, 44, 175, 59
+LTEXT           "Version:", IDC_JINI_VERSION, 188, 64, 166, 8
+PUSHBUTTON      "visit home page", IDC_JINI_HOME, 188, 85, 163, 13
+LTEXT           "Date:", IDC_JINI_DATE, 188, 74, 166, 8
+LTEXT           "Author:", IDC_JINI_AUTHOR, 188, 53, 166, 8
+GROUPBOX        " Current Language ", IDC_LAN, 7, 0, 348, 42
 END
 
 IDD_Settings_General DIALOG 0, 0, 231, 206

--- a/resource.h
+++ b/resource.h
@@ -205,6 +205,12 @@
 #define IDC_CHEAT_CODES                 1178
 #define IDC_STATE                       1179
 #define IDC_CHEATSFRAME                 1188
+#define IDC_JINI                        1184
+#define IDC_JINI_VERSION                1185
+#define IDC_JINI_HOME                   1186
+#define IDC_JINI_DATE                   1187
+#define IDC_CHEATSFRAME                 1188
+#define IDC_JINI_AUTHOR                 1188
 #define IDC_ADDCHEATSFRAME              1189
 #define IDC_CORE_DEFAULTS               1190
 #define IDC_CHEAT_OPTIONS               1190


### PR DESCRIPTION
This adds Jabo Perm Cheat function to use specifically from the Jabo.ini so they do not effect any other plugin by using the RDB.  It also Adds the Jabo ini to the About INI Dialog.